### PR TITLE
Update link to 20 cities dataset download

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ python setup.py install
 
 ## 1. Dataset preparation
 
-Please download [20 US Cities dataset](https://github.com/songtaohe/Sat2Graph/tree/master/prepare_dataset) and organize them as following:
+Please download [20 US Cities dataset](https://drive.google.com/drive/folders/1FlMcO3Jr8W4qboZUwxgRn6AlYc-AuxQ2?usp=sharing) and organize them as follows:
 
 ```
 code_root/


### PR DESCRIPTION
According to https://github.com/songtaohe/Sat2Graph/tree/master#download-the-dataset-and-pre-trained-model the script to download the 20 cities dataset doesn't work anymore and the dataset should be downloaded from Google Drive directly.